### PR TITLE
Set up GitHub actions

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,16 @@
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project: no
+    patch: yes
+    changes: no
+
+comment:
+  layout: "header, diff, changes, tree"
+  behavior: default
+
+ignore:
+  - "tst/**"  # ignore test harness code

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,39 @@
+name: CI
+
+# Trigger the workflow on push or pull request
+on:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
+
+# the `concurrency` settings ensure that not too many CI jobs run in parallel
+concurrency:
+  # group by workflow and ref; the last slightly strange component ensures that for pull
+  # requests, we limit to 1 concurrent job, but for the master branch we don't
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/master' || github.run_number }}
+  # Cancel intermediate builds, but only if it is a pull request build.
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+jobs:
+  # The CI test job
+  test:
+    name: ${{ matrix.gap-branch }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        gap-branch:
+          - master
+          - stable-4.12
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: gap-actions/setup-gap@v2
+        with:
+          GAPBRANCH: ${{ matrix.gap-branch }}
+      - uses: gap-actions/build-pkg@v1
+      - uses: gap-actions/run-pkg-tests@v2
+      - uses: gap-actions/process-coverage@v2
+      - uses: codecov/codecov-action@v3

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -1,0 +1,92 @@
+SetPackageInfo( rec(
+PackageName := "YangBaxterExtensions",
+Subtitle := "Combinatorial Solutions for the Yang-Baxter equation",
+Version := "0.10.3",
+Date := "25/02/2023", # dd/mm/yyyy format
+License := "GPL-3.0",
+
+PackageWWWHome :=
+  Concatenation( "https://gap-packages.github.io/", ~.PackageName ),
+SourceRepository := rec(
+    Type := "git",
+    URL := Concatenation( "https://github.com/gap-packages/", ~.PackageName ),
+),
+IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
+
+ArchiveURL := Concatenation( ~.SourceRepository.URL,
+                                 "/releases/download/v", ~.Version,
+                                 "/", ~.PackageName, "-", ~.Version ),
+ArchiveFormats := ".tar.gz",
+
+Persons := [
+  rec( 
+    LastName      := "Vendramin",
+    FirstNames    := "Leandro",
+    IsAuthor      := true,
+    IsMaintainer  := true,
+    Email         := "Leandro.Vendramin@vub.be",
+    WWWHome       := "https://vendramin.github.io/",
+    PostalAddress := Concatenation( [
+                       "Vrije Universiteit Brussel\n",
+                       "Faculty of Sciences\n",
+                       "Department of Mathematics and Data Science\n",
+                       "Pleinlaan 2, B-1050\n",
+                       "Brussel, Belgium" ] ),
+    Place         := "Brussels",
+    Institution   := "Vrije Universiteit Brussel"
+  ),
+  rec( 
+    LastName      := "Konovalov",
+    FirstNames    := "Olexandr",
+    IsAuthor      := true,
+    IsMaintainer  := true,
+    Email         := "obk1@st-andrews.ac.uk",
+    WWWHome       := "https://olexandr-konovalov.github.io/",
+    PostalAddress := Concatenation( [
+                     "School of Computer Science\n",
+                     "University of St Andrews\n",
+                     "Jack Cole Building, North Haugh,\n",
+                     "St Andrews, Fife, KY16 9SX, Scotland" ] ),
+    Place         := "St Andrews",
+    Institution   := "University of St Andrews"
+     ),  
+],
+
+Status := "deposited",
+
+README_URL := 
+  Concatenation( ~.PackageWWWHome, "/README.md" ),
+PackageInfoURL := 
+  Concatenation( ~.PackageWWWHome, "/PackageInfo.g" ),
+
+AbstractHTML := 
+"The <span class=\"pkgname\">YangBaxter</span> package provides functionality \
+to construct classical and skew braces. It also includes a database of classical \
+and skew braces of small orders.",
+   
+PackageDoc := rec(
+  BookName  := ~.PackageName,
+  ArchiveURLSubset := ["doc"],
+  HTMLStart := "doc/chap0.html",
+  PDFFile   := "doc/manual.pdf",
+  # the path to the .six file used by GAP's help system
+  SixFile   := "doc/manual.six",
+  # a longer title of the book, this together with the book name should
+  # fit on a single text line (appears with the '?books' command in GAP)
+  LongTitle := ~.Subtitle,
+),
+
+Dependencies := rec(
+   GAP := ">=4.9",
+  NeededOtherPackages := [ [ "cryst", ">=4.0" ] ],
+  SuggestedOtherPackages := [ ],
+  ExternalConditions := [ ]
+),
+
+AvailabilityTest := ReturnTrue,
+
+TestFile := "tst/testall.g",
+
+Keywords := ["QYBE", "cycle sets", "racks", "quandles", "braces", "radical rings"]
+
+));

--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
+[![Build Status](https://github.com/VanAntwerpen/gap_experiments/workflows/CI/badge.svg?branch=main)](https://github.com/VanAntwerpen/gap_experiments/actions?query=workflow%3ACI+branch%3Amain)
+[![Code Coverage](https://codecov.io/github/VanAntwerpen/gap_experiments/coverage.svg?branch=main&token=)](https://codecov.io/gh/VanAntwerpen/gap_experiments)
+
 # gap_experiments

--- a/tst/testall.g
+++ b/tst/testall.g
@@ -1,0 +1,27 @@
+LoadPackage( "YangBaxter" );
+Read("extrafunctions.g");
+
+# `TestDirectory` provides a convenient way to run collections of tests.
+# It also simplifies adding new tests, because it automatically picks
+# up all files having extension `.tst`
+#
+# It also ensures that it will display an information message that is
+# needed to detect whether a test passed or failed in a number of automated
+# settings.
+#
+# If you need to run some other tests in addition to `TestDirectory`,
+# you code should analyse the outcome of the test, and then
+# print an information using the string that looks exactly as shown below:
+#
+# if testresult 
+#   Print("#I  No errors detected while testing"\n");
+# else
+#   Print("#I  Errors detected while testing\n");
+# fi;
+#
+#
+TestDirectory( "tst" ,
+  rec(exitGAP     := true,
+      testOptions := rec(compareFunction := "uptowhitespace") ) );
+
+FORCE_QUIT_GAP(1); # if we ever get here, there was an error


### PR DESCRIPTION
Used setup from the GAP Example package (https://github.com/gap-packages/example). It insisted on `PackageInfo.g` file, so for now I tool the one from the YangBaxter package and only changed the package name. You can update other fields later.